### PR TITLE
Upload the 8.1.0-rc2 release link on the website

### DIFF
--- a/content/download/releases/v8-1-0-rc2.md
+++ b/content/download/releases/v8-1-0-rc2.md
@@ -1,0 +1,33 @@
+---
+title: "8.1.0-rc2"
+date: 2025-03-24 06:44:48
+extra:
+    tag: "8.1.0-rc2"
+    artifact_source: https://download.valkey.io/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        -
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "8.1.0-rc2"
+                - "8.1.0-rc2-bookworm"
+                - "8.1.0-rc2-alpine"
+                - "8.1.0-rc2-alpine3.21"
+    packages:
+
+    artifacts:
+        -   distro: focal
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: jammy
+            arch:
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   x86_64
+---
+
+Valkey 8.1.0-rc2 Release


### PR DESCRIPTION
THis pull request adds a new release link on the website for Valkey version 8.1.0-rc2.