### PR TITLE
Update the 8.1.0-rc2 release link on the website

### DIFF
--- a/content/download/releases/v8-1-0.md
+++ b/content/download/releases/v8-1-0.md
@@ -1,6 +1,6 @@
 ---
 title: "8.1.0-rc2"
-date: 2025-03-20
+date: 2025-03-24
 extra:
     tag: "8.1.0-rc2"
     artifact_source: https://download.valkey.io/releases/


### PR DESCRIPTION
This pull request updates the release link for Valkey version 8.1.0-rc2.
- **RC versions update the existing major version file**.
- **Stable releases create new files.**