### PR TITLE
Update the 8.1.0-rc1 release link on the website

### DIFF
--- a/content/download/releases/v8-1-0.md
+++ b/content/download/releases/v8-1-0.md
@@ -1,8 +1,8 @@
 ---
-title: "8.1.0-rc2"
-date: 2025-03-20
+title: "8.1.0-rc1"
+date: 2025-03-24
 extra:
-    tag: "8.1.0-rc2"
+    tag: "8.1.0-rc1"
     artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
@@ -31,4 +31,4 @@ extra:
                 -   x86_64
 ---
 
-Valkey 8.1.0-rc2 Release
+Valkey 8.1.0-rc1 Release


### PR DESCRIPTION
This pull request updates the release link for Valkey version 8.1.0-rc1.
- **RC versions update the existing major version file**.
- **Stable releases create new files.**