### PR TITLE
Update the 8.0.0 release link on the website

### DIFF
--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -1,12 +1,12 @@
 ---
 title: "8.0.0"
-date: 2024-09-16
+date: 2025-03-24
 extra:
     tag: "8.0.0"
     artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
-        - 
+        -
             name: "Docker Hub"
             link: https://hub.docker.com/r/valkey/valkey/
             id: "valkey/valkey"
@@ -14,7 +14,7 @@ extra:
                 - "8.0.0"
                 - "8.0.0-bookworm"
                 - "8.0.0-alpine"
-                - "8.0.0-alpine3.20"
+                - "8.0.0-alpine3.21"
     packages:
 
     artifacts:
@@ -24,7 +24,6 @@ extra:
                 -   x86_64
         -   distro: jammy
             arch:
-                -   arm64
                 -   x86_64
         -   distro: noble
             arch:


### PR DESCRIPTION
This pull request updates the release link for Valkey version 8.0.0 on the website.