### PR TITLE
Update the 8.1.0-rc2 release link on the website

### DIFF
--- a/content/download/releases/v8-1-0.md
+++ b/content/download/releases/v8-1-0.md
@@ -1,6 +1,6 @@
 ---
 title: "8.1.0-rc2"
-date: 2025-03-20
+date: 2025-03-27
 extra:
     tag: "8.1.0-rc2"
     artifact_source: https://download.valkey.io/releases/
@@ -11,11 +11,8 @@ extra:
             link: https://hub.docker.com/r/valkey/valkey/
             id: "valkey/valkey"
             tags:
-                - "8.1"
-                - "8.1-bookworm"
-                - "8.1-alpine"
-                - "8.1-alpine3.21"
-    packages:
+                - ""
+            packages:
 
     artifacts:
         -   distro: focal


### PR DESCRIPTION
This pull request updates the release link for Valkey version 8.1.0-rc2.
- Tags are dynamically generated from bashbrew output