### PR TITLE
Update website for version 8.1.0-rc2

### DIFF
--- a/content/download/releases/v8-1-0.md
+++ b/content/download/releases/v8-1-0.md
@@ -1,20 +1,17 @@
 ---
 title: "8.1.0-rc2"
-date: 2025-03-20
+date: 2025-03-27
 extra:
     tag: "8.1.0-rc2"
     artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
-        - 
+        -
             name: "Docker Hub"
             link: https://hub.docker.com/r/valkey/valkey/
             id: "valkey/valkey"
             tags:
-                - "8.1"
-                - "8.1-bookworm"
-                - "8.1-alpine"
-                - "8.1-alpine3.21"
+
     packages:
 
     artifacts:
@@ -24,7 +21,6 @@ extra:
                 -   x86_64
         -   distro: jammy
             arch:
-                -   arm64
                 -   x86_64
         -   distro: noble
             arch:


### PR DESCRIPTION
This pull request updates the release link for Valkey version 8.1.0-rc2.
- Tags are dynamically generated from bashbrew output