### PR TITLE
Update website for version 8.0.0

### DIFF
--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -1,20 +1,24 @@
 ---
 title: "8.0.0"
-date: 2024-09-16
+date: 2025-03-28
 extra:
     tag: "8.0.0"
     artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
-        - 
+        -
             name: "Docker Hub"
             link: https://hub.docker.com/r/valkey/valkey/
             id: "valkey/valkey"
             tags:
-                - "8.0.0"
-                - "8.0.0-bookworm"
-                - "8.0.0-alpine"
-                - "8.0.0-alpine3.20"
+                - "8.0.2"
+                - "8.0"
+                - "8.0.2-bookworm"
+                - "8.0-bookworm"
+                - "8.0.2-alpine"
+                - "8.0-alpine"
+                - "8.0.2-alpine3.21"
+                - "8.0-alpine3.21"
     packages:
 
     artifacts:


### PR DESCRIPTION
This pull request updates the release link for Valkey version 8.0.0.
- Tags are dynamically generated from bashbrew output