### PR TITLE
Update website for version 7.2.8

### DIFF
--- a/content/download/releases/v7-2-8.md
+++ b/content/download/releases/v7-2-8.md
@@ -1,6 +1,6 @@
 ---
 title: "7.2.8"
-date: 2025-01-07 01:01:02
+date: 2025-03-28
 extra:
     tag: "7.2.8"
     artifact_source: https://download.valkey.io/releases/
@@ -12,9 +12,13 @@ extra:
             id: "valkey/valkey"
             tags:
                 - "7.2.8"
+                - "7.2"
                 - "7.2.8-bookworm"
+                - "7.2-bookworm"
                 - "7.2.8-alpine"
+                - "7.2-alpine"
                 - "7.2.8-alpine3.21"
+                - "7.2-alpine3.21"
     packages:
 
     artifacts:
@@ -24,6 +28,7 @@ extra:
                 -   x86_64
         -   distro: jammy
             arch:
+                -   arm64
                 -   x86_64
         -   distro: noble
             arch:


### PR DESCRIPTION
This pull request updates the release link for Valkey version 7.2.8.
- Tags are dynamically generated from bashbrew output