### PR TITLE
Update website for version 8.1.0-rc2

### DIFF
--- a/content/download/releases/v8-1-0.md
+++ b/content/download/releases/v8-1-0.md
@@ -1,12 +1,12 @@
 ---
 title: "8.1.0-rc2"
-date: 2025-03-20
+date: 2025-03-31
 extra:
     tag: "8.1.0-rc2"
     artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
-        - 
+        -
             name: "Docker Hub"
             link: https://hub.docker.com/r/valkey/valkey/
             id: "valkey/valkey"


### PR DESCRIPTION
This pull request updates the downloads page of the valkey website with the new release 8.1.0-rc2.
Please review the changes and merge when appropriate.