### PR TITLE
Update website for version 8.0.0-rc1

### DIFF
--- a/content/download/releases/v8-0-0.md
+++ b/content/download/releases/v8-0-0.md
@@ -1,38 +1,35 @@
 ---
-title: "8.0.0"
-date: 2024-09-16
+title: "8.0.0-rc1"
+date: 2025-08-13
 extra:
-    tag: "8.0.0"
+    tag: "8.0.0-rc1"
     artifact_source: https://download.valkey.io/releases/
     artifact_fname: "valkey"
     container_registry:
-        - 
+        -
             name: "Docker Hub"
             link: https://hub.docker.com/r/valkey/valkey/
             id: "valkey/valkey"
             tags:
-                - "8.0.0"
-                - "8.0.0-bookworm"
-                - "8.0.0-alpine"
-                - "8.0.0-alpine3.20"
+                - "8.0.4"
+                - "8.0"
+                - "8.0.4-trixie"
+                - "8.0-trixie"
+                - "8.0.4-alpine"
+                - "8.0-alpine"
+                - "8.0.4-alpine3.22"
+                - "8.0-alpine3.22"
     packages:
 
     artifacts:
-        -   distro: bionic
-            arch:
-                -   arm64
-                -   x86_64
-        -   distro: focal
-            arch:
-                -   arm64
-                -   x86_64
         -   distro: jammy
             arch:
                 -   arm64
                 -   x86_64
         -   distro: noble
             arch:
+                -   arm64
                 -   x86_64
 ---
 
-Valkey 8.0.0 Release
+Valkey 8.0.0-rc1 Release


### PR DESCRIPTION
This pull request updates the downloads page of the valkey website with the new release 8.0.0-rc1.
Please review the changes and merge when appropriate.