### PR TITLE
Update website for version 9.0.0-rc2

### DIFF
--- a/content/download/releases/v9-0-0-rc2.md
+++ b/content/download/releases/v9-0-0-rc2.md
@@ -1,0 +1,35 @@
+---
+title: "9.0.0-rc2"
+date: 2025-08-27
+extra:
+    tag: "9.0.0-rc2"
+    artifact_source: https://download.valkey.io/releases/
+    artifact_fname: "valkey"
+    container_registry:
+        -
+            name: "Docker Hub"
+            link: https://hub.docker.com/r/valkey/valkey/
+            id: "valkey/valkey"
+            tags:
+                - "9.0.0"
+                - "9.0"
+                - "9.0.0-trixie"
+                - "9.0-trixie"
+                - "9.0.0-alpine"
+                - "9.0-alpine"
+                - "9.0.0-alpine3.22"
+                - "9.0-alpine3.22"
+    packages:
+
+    artifacts:
+        -   distro: jammy
+            arch:
+                -   arm64
+                -   x86_64
+        -   distro: noble
+            arch:
+                -   arm64
+                -   x86_64
+---
+
+Valkey 9.0.0-rc2 Release


### PR DESCRIPTION
This pull request updates the downloads page of the valkey website with the new release 9.0.0-rc2.
Please review the changes and merge when appropriate.